### PR TITLE
fix(runtime): accept bounded large app-server frames

### DIFF
--- a/modules/core/src/main/java/de/agentcodi/core/CodexAppServerClient.java
+++ b/modules/core/src/main/java/de/agentcodi/core/CodexAppServerClient.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class CodexAppServerClient implements AutoCloseable {
-    public static final int MAX_INCOMING_BYTES = 1024 * 1024;
+    public static final int MAX_INCOMING_BYTES = 16 * 1024 * 1024;
     public static final int MAX_OUTGOING_BYTES = 256 * 1024;
     public static final long MAX_REQUEST_ID = Integer.MAX_VALUE;
     public static final int MAX_PENDING_SERVER_REQUESTS = 16;

--- a/modules/core/src/main/java/de/agentcodi/core/JsonCodec.java
+++ b/modules/core/src/main/java/de/agentcodi/core/JsonCodec.java
@@ -8,9 +8,11 @@ import java.util.Map;
 
 public final class JsonCodec {
     private static final int MAX_INPUT_CHARACTERS = 16 * 1024 * 1024;
+    private static final int MAX_OUTPUT_CHARACTERS = 1024 * 1024;
     private static final int MAX_DEPTH = 64;
     private static final int MAX_CONTAINER_ENTRIES = 10_000;
-    private static final int MAX_STRING_CHARACTERS = 16 * 1024 * 1024;
+    private static final int MAX_INPUT_STRING_CHARACTERS = 16 * 1024 * 1024;
+    private static final int MAX_OUTPUT_STRING_CHARACTERS = 512 * 1024;
 
     private JsonCodec() {
     }
@@ -32,7 +34,7 @@ public final class JsonCodec {
     public static String stringify(Object value) {
         StringBuilder output = new StringBuilder();
         appendValue(output, value, 0);
-        if (output.length() > MAX_INPUT_CHARACTERS) {
+        if (output.length() > MAX_OUTPUT_CHARACTERS) {
             throw new IllegalArgumentException("JSON exceeds the output limit");
         }
         return output.toString();
@@ -179,7 +181,7 @@ public final class JsonCodec {
     }
 
     private static void appendString(StringBuilder output, String value) {
-        if (value.length() > MAX_STRING_CHARACTERS) {
+        if (value.length() > MAX_OUTPUT_STRING_CHARACTERS) {
             throw new IllegalArgumentException("JSON string exceeds the limit");
         }
         output.append('"');
@@ -386,7 +388,7 @@ public final class JsonCodec {
                     }
                     value.append(character);
                 }
-                if (value.length() > MAX_STRING_CHARACTERS) {
+                if (value.length() > MAX_INPUT_STRING_CHARACTERS) {
                     fail("JSON string exceeds the limit");
                 }
             }
@@ -502,7 +504,7 @@ public final class JsonCodec {
     }
 
     private static void ensureOutputLimit(StringBuilder output) {
-        if (output.length() > MAX_INPUT_CHARACTERS) {
+        if (output.length() > MAX_OUTPUT_CHARACTERS) {
             throw new IllegalArgumentException("JSON exceeds the output limit");
         }
     }

--- a/modules/core/src/main/java/de/agentcodi/core/JsonCodec.java
+++ b/modules/core/src/main/java/de/agentcodi/core/JsonCodec.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Map;
 
 public final class JsonCodec {
-    private static final int MAX_INPUT_CHARACTERS = 1024 * 1024;
+    private static final int MAX_INPUT_CHARACTERS = 16 * 1024 * 1024;
     private static final int MAX_DEPTH = 64;
     private static final int MAX_CONTAINER_ENTRIES = 10_000;
-    private static final int MAX_STRING_CHARACTERS = 512 * 1024;
+    private static final int MAX_STRING_CHARACTERS = 16 * 1024 * 1024;
 
     private JsonCodec() {
     }

--- a/modules/native-engine/src/main/cpp/jni_bridge.cpp
+++ b/modules/native-engine/src/main/cpp/jni_bridge.cpp
@@ -261,7 +261,7 @@ Java_de_agentcodi_runtime_NativeEngine_nativeReadAppServerLine(
     jclass,
     jlong handle,
     jint maximum_bytes) {
-  if (maximum_bytes <= 0 || maximum_bytes > 1024 * 1024) {
+  if (maximum_bytes <= 0 || maximum_bytes > 16 * 1024 * 1024) {
     throw_io_exception(environment, "Incoming app-server byte limit is invalid");
     return nullptr;
   }

--- a/tests/java/de/agentcodi/tests/CodexLargeIncomingFrameTest.java
+++ b/tests/java/de/agentcodi/tests/CodexLargeIncomingFrameTest.java
@@ -1,0 +1,177 @@
+package de.agentcodi.tests;
+
+import de.agentcodi.core.CodexAppServerClient;
+import de.agentcodi.core.CodexRpcTransport;
+import de.agentcodi.core.JsonCodec;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public final class CodexLargeIncomingFrameTest {
+    private CodexLargeIncomingFrameTest() {
+    }
+
+    public static int run() throws Exception {
+        acceptsIncomingFrameAboveOneMiB();
+        return 1;
+    }
+
+    private static void acceptsIncomingFrameAboveOneMiB() throws Exception {
+        LargeFrameTransport transport = new LargeFrameTransport();
+        RecordingListener listener = new RecordingListener();
+        CodexAppServerClient client = new CodexAppServerClient(transport, listener);
+        client.start();
+        client.initialize(
+            JsonCodec.object(
+                "clientInfo",
+                JsonCodec.object("name", "fixture", "title", "Fixture", "version", "1")
+            ),
+            1_000L
+        );
+
+        final int payloadLength = 2 * 1024 * 1024;
+        StringBuilder payload = new StringBuilder(payloadLength);
+        for (int index = 0; index < payloadLength; index++) {
+            payload.append('x');
+        }
+        String frame = "{\"method\":\"fixture/largeNotification\",\"params\":{\"payload\":\""
+            + payload.toString()
+            + "\"}}";
+        TestSupport.assertTrue(
+            frame.getBytes(StandardCharsets.UTF_8).length > 1024 * 1024,
+            "fixture must exceed the old 1 MiB limit"
+        );
+        TestSupport.assertTrue(
+            frame.getBytes(StandardCharsets.UTF_8).length < CodexAppServerClient.MAX_INCOMING_BYTES,
+            "fixture must stay below the configured incoming limit"
+        );
+
+        transport.enqueue(frame);
+        waitFor(new Condition() {
+            @Override
+            public boolean isTrue() {
+                return listener.payloadLength == payloadLength;
+            }
+        }, "large incoming notification dispatch");
+        TestSupport.assertEquals(
+            "fixture/largeNotification",
+            listener.method,
+            "large incoming method"
+        );
+        TestSupport.assertEquals(
+            Integer.valueOf(payloadLength),
+            Integer.valueOf(listener.payloadLength),
+            "large incoming payload length"
+        );
+        TestSupport.assertEquals(null, listener.transportFailure, "transport remains open");
+        client.close();
+    }
+
+    private static void waitFor(Condition condition, String message) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000L;
+        while (!condition.isTrue() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10L);
+        }
+        TestSupport.assertTrue(condition.isTrue(), message);
+    }
+
+    private interface Condition {
+        boolean isTrue();
+    }
+
+    private static final class RecordingListener implements CodexAppServerClient.Listener {
+        private volatile String method;
+        private volatile int payloadLength = -1;
+        private volatile Throwable transportFailure;
+
+        @Override
+        public boolean onServerRequest(
+            long requestId,
+            String method,
+            Map<String, Object> params
+        ) {
+            return false;
+        }
+
+        @Override
+        public void onNotification(String method, Map<String, Object> params) {
+            this.method = method;
+            String payload = JsonCodec.optionalString(params.get("payload"));
+            payloadLength = payload.length();
+        }
+
+        @Override
+        public void onTransportClosed(Throwable error) {
+            transportFailure = error;
+        }
+    }
+
+    private static final class LargeFrameTransport implements CodexRpcTransport {
+        private static final Object CLOSED = new Object();
+        private final LinkedBlockingQueue<Object> incoming = new LinkedBlockingQueue<Object>();
+        private volatile boolean closed;
+
+        @Override
+        public String readLine(int maximumBytes) throws IOException {
+            try {
+                Object value = incoming.take();
+                if (value == CLOSED) {
+                    return null;
+                }
+                String line = (String) value;
+                if (line.getBytes(StandardCharsets.UTF_8).length > maximumBytes) {
+                    throw new IOException("fixture line too large");
+                }
+                return line;
+            } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                throw new IOException("fixture interrupted", error);
+            }
+        }
+
+        @Override
+        public void writeLine(String line, int maximumBytes) throws IOException {
+            byte[] bytes = line.getBytes(StandardCharsets.UTF_8);
+            writeBytes(bytes, bytes.length, maximumBytes);
+        }
+
+        @Override
+        public void writeBytes(byte[] line, int length, int maximumBytes) throws IOException {
+            if (closed) {
+                throw new IOException("fixture closed");
+            }
+            if (line == null || length <= 0 || length > line.length || length > maximumBytes) {
+                throw new IOException("fixture outgoing bytes too large");
+            }
+            byte[] copy = Arrays.copyOf(line, length);
+            try {
+                Map<String, Object> message = JsonCodec.parseObject(
+                    new String(copy, StandardCharsets.UTF_8)
+                );
+                if ("initialize".equals(JsonCodec.optionalString(message.get("method")))) {
+                    enqueue(JsonCodec.stringify(JsonCodec.object(
+                        "id", message.get("id"),
+                        "result", JsonCodec.object("userAgent", "fixture/1")
+                    )));
+                }
+            } finally {
+                Arrays.fill(copy, (byte) 0);
+                Arrays.fill(line, (byte) 0);
+            }
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            incoming.offer(CLOSED);
+        }
+
+        private void enqueue(String line) {
+            incoming.offer(line);
+        }
+    }
+}

--- a/tests/java/de/agentcodi/tests/TestMain.java
+++ b/tests/java/de/agentcodi/tests/TestMain.java
@@ -12,6 +12,7 @@ public final class TestMain {
         passed += CustomReviewModeTest.run();
         passed += JsonCodecTest.run();
         passed += CodexAppServerClientTest.run();
+        passed += CodexLargeIncomingFrameTest.run();
         passed += CodexWorkspaceAttachmentContextTest.run();
         passed += CodexSessionControllerTest.run();
         passed += McpCatalogLoaderTest.run();


### PR DESCRIPTION
Fixes #2.

Raises the inbound Codex app-server frame limit to 16 MiB across the Java RPC client, JNI read validation, and inbound JSON parsing while preserving the existing outbound JSON limits.

Also adds a regression test for an incoming Codex notification larger than 1 MiB and registers it in the existing Java test runner.

Reproduced on Android arm64-v8a with AGENTCODI 0.6.7 and Codex 0.148.1.