### PR TITLE
fix(core): keep the terminal omission marker after repeated trims

### DIFF
--- a/modules/core/src/main/java/de/agentcodi/core/TerminalOutputBuffer.java
+++ b/modules/core/src/main/java/de/agentcodi/core/TerminalOutputBuffer.java
@@ -19,7 +19,6 @@ public final class TerminalOutputBuffer {
     private int ansiState;
     private int ansiSequenceCharacters;
     private boolean carriageReturn;
-    private boolean omitted;
 
     public void append(byte[] bytes) {
         if (bytes == null || bytes.length == 0) {
@@ -73,7 +72,6 @@ public final class TerminalOutputBuffer {
         ansiState = ANSI_NORMAL;
         ansiSequenceCharacters = 0;
         carriageReturn = false;
-        omitted = false;
     }
 
     public String snapshot() {
@@ -177,10 +175,9 @@ public final class TerminalOutputBuffer {
             remove++;
         }
         output.delete(0, Math.min(remove, output.length()));
-        if (!omitted) {
-            output.insert(0, OMITTED_PREFIX);
-            omitted = true;
-        }
+        // Every trim drops the head of the buffer, including a marker that an
+        // earlier trim inserted, so the notice has to be written again.
+        output.insert(0, OMITTED_PREFIX);
         if (output.length() > MAXIMUM_CHARACTERS) {
             output.delete(
                 OMITTED_PREFIX.length(),

--- a/tests/java/de/agentcodi/tests/TerminalOutputBufferTest.java
+++ b/tests/java/de/agentcodi/tests/TerminalOutputBufferTest.java
@@ -12,10 +12,11 @@ public final class TerminalOutputBufferTest {
     public static int run() {
         decodesSplitUtf8AndStripsTerminalControls();
         boundsOutputAndMarksOmission();
+        keepsOmissionMarkerAcrossRepeatedTrims();
         redactsCredentialShapesFromSnapshots();
         finishesIncompleteUtf8Safely();
         removesRemainingControlsAndResetsIncompleteAnsi();
-        return 5;
+        return 6;
     }
 
     private static void decodesSplitUtf8AndStripsTerminalControls() {
@@ -56,6 +57,36 @@ public final class TerminalOutputBufferTest {
         TestSupport.assertTrue(
             snapshot.startsWith("[earlier terminal output omitted]"),
             "terminal omission marker"
+        );
+    }
+
+    private static void keepsOmissionMarkerAcrossRepeatedTrims() {
+        TerminalOutputBuffer buffer = new TerminalOutputBuffer();
+        byte[] oversized = new byte[TerminalOutputBuffer.MAXIMUM_CHARACTERS + 4096];
+        Arrays.fill(oversized, (byte) 'x');
+        buffer.append(oversized);
+        buffer.append("\nolder command output\n".getBytes(StandardCharsets.UTF_8));
+        buffer.append(oversized);
+        String snapshot = buffer.snapshot();
+        TestSupport.assertTrue(
+            snapshot.length() <= TerminalOutputBuffer.MAXIMUM_CHARACTERS,
+            "terminal snapshot limit after a second trim"
+        );
+        TestSupport.assertFalse(
+            snapshot.contains("older command output"),
+            "second trim drops the oldest terminal output"
+        );
+        TestSupport.assertTrue(
+            snapshot.startsWith("[earlier terminal output omitted]"),
+            "terminal omission marker survives a second trim"
+        );
+        TestSupport.assertEquals(
+            Integer.valueOf(-1),
+            Integer.valueOf(snapshot.indexOf(
+                "[earlier terminal output omitted]",
+                1
+            )),
+            "terminal omission marker is not duplicated"
         );
     }
 


### PR DESCRIPTION
The terminal output buffer inserted "[earlier terminal output omitted]"
only on the first trim. Every later trim deletes the head of the buffer,
including that marker, but the omitted flag suppressed re-inserting it.
A long-running terminal session therefore showed a silently truncated
buffer that looked complete.

Restore the marker on every trim. Because a trim always removes more
characters than the marker is long, exactly one marker remains.

